### PR TITLE
Added 0.0.0.0 as host to HTTP Server

### DIFF
--- a/prometheus-integration/com.tibco.bw.prometheus.monitor/src/com/tibco/bw/prometheus/monitor/PrometheusCollector.java
+++ b/prometheus-integration/com.tibco.bw.prometheus.monitor/src/com/tibco/bw/prometheus/monitor/PrometheusCollector.java
@@ -31,7 +31,7 @@ import com.tibco.neo.exception.BaseException;
 public class PrometheusCollector extends Collector {
 	private static Logger logger = LoggerFactory.getLogger(PrometheusCollector.class);
 	public static HTTPServer server;
-	private final static InetSocketAddress DEFAULT_PROMETHEUS_MONITOR_PORT = new InetSocketAddress(9095);
+	private final static InetSocketAddress DEFAULT_PROMETHEUS_MONITOR_PORT = new InetSocketAddress("0.0.0.0",9095);
 	
 	private static final QName HTTPCONNECTOR_TYPE = new QName("http://xsd.tns.tibco.com/bw/models/sharedresource/httpconnector","HttpConnectorConfiguration");
 	private final static CountDownLatch proxyInitLatch = new CountDownLatch(1);


### PR DESCRIPTION
Prometheus collector doesn't work when service mesh is enabled since the it uses hostname and not localhost or 0.0.0.0.
Added "0.0.0.0" as host to InetSocketAddress to resolve this issue.