### PR TITLE
Fix for https://jira.tibco.com/browse/BWCE-5346: BW Prometheus plugin is not working.

### DIFF
--- a/prometheus-integration/com.tibco.bw.prometheus.monitor/META-INF/MANIFEST.MF
+++ b/prometheus-integration/com.tibco.bw.prometheus.monitor/META-INF/MANIFEST.MF
@@ -16,7 +16,7 @@ Require-Bundle: com.tibco.bw.thor.management.common
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy
 Import-Package: .;version="1.0.200",
- com.tibco.bw.frwk.api;version="[1.2.3000,2.0.0)",
+ com.tibco.bw.frwk.api;version="[1.0.0,2.0.0)",
  com.tibco.bw.runtime;version="[6.2.100,7.0.0)",
  com.tibco.bw.runtime.event;version="[6.2.100,7.0.0)",
  com.tibco.bw.sharedresource.http.inbound.api;version="6.2.700",


### PR DESCRIPTION
Updating the version range of the plugin "com.tibco.bw.frwk.api" so that the plugin will compile in the older versions of the Studio too.